### PR TITLE
fix(web): DevToolsTrigger 触发区从 330px 缩到 10px - 解除对 footer 右侧遮挡

### DIFF
--- a/apps/web/src/components/dev/DevToolsTrigger.tsx
+++ b/apps/web/src/components/dev/DevToolsTrigger.tsx
@@ -173,7 +173,7 @@ export function DevToolsTrigger() {
      * 即使面板收起时也能看到并被悬停触发。
      */
     <div
-      className="fixed right-0 top-0 z-50 flex h-screen"
+      className="fixed right-0 top-0 z-50 h-screen w-[10px]"
       onMouseEnter={handleMouseEnter}
       onMouseLeave={handleMouseLeave}
       aria-label={t('trigger')}
@@ -181,13 +181,12 @@ export function DevToolsTrigger() {
       {/* 拉出的面板 - 320px 宽,从右往左滑入 */}
       <div
         className={[
-          'flex h-full w-80 flex-col border-l bg-background shadow-xl',
+          'absolute right-full top-0 flex h-full w-80 flex-col border-l bg-background shadow-xl',
           'transition-transform duration-200 ease-out',
           // 收起时 translate-x-full 把自己推到视口外,只露把手
-          hover ? 'translate-x-0' : 'translate-x-full',
         ].join(' ')}
         // 收起时不接收 pointer events,避免挡住下方页面元素;展开时正常接收
-        style={{ pointerEvents: hover ? 'auto' : 'none' }}
+        style={{ pointerEvents: hover ? 'auto' : 'none', transform: hover ? 'translateX(0)' : 'translateX(100%)' }}
         aria-hidden={!hover}
       >
         {/* 面板头部 */}
@@ -282,7 +281,7 @@ export function DevToolsTrigger() {
       {/* 收起时也保持可见,作为悬停触发器 */}
       <div
         className={[
-          'flex h-full w-[10px] shrink-0 flex-col items-center justify-center',
+          'flex h-full w-full flex-col items-center justify-center',
           'border-l border-border/60 bg-foreground/5',
           'transition-colors duration-150',
           hover ? 'bg-foreground/15' : 'hover:bg-foreground/10',


### PR DESCRIPTION
## 修复内容

DevToolsTrigger (开发者工具悬浮抽屉) 触发区从 330px 缩小到 10px, 解除对 footer 右侧内容的遮挡。

## 根因

旧实现外层容器 `flex h-screen` + 子元素面板(320px) + 把手(10px), flex 布局使容器实际命中宽度 = 330px。即便面板被 `translate-x-full` 推到视口外 (视觉不可见), flex 仍保留 320px 占位, 鼠标进入右侧 330px 区域就触发 hover, 挡住底部 footer 右侧约 320px 的内容。

## 修复方案

- 外层固定 `w-[10px]` = 仅把手宽度
- 面板改为 `absolute right-full top-0` 脱离文档流, 不再撑大外层
- transform 从 Tailwind 类改为 inline style (translate-x-full 在 Tailwind 4 Turbopack 编译异常)
- 把手 `w-[10px] shrink-0` -> `w-full`

## 验证证据 (SSR HTML + browser DOM 全部 PASS)

- outer.width = 10
- outer.left = viewportWidth - 10
- panel.style.transform = translateX(100%) (默认隐藏)
- panel.transform computed = matrix(1,0,0,1,320,0)
- panel.pointerEvents = none
- panel.right > viewportWidth (默认在视口外)
- footerRight50NotBlocked = true (footer 右 50px 不被遮挡)

## 测试

用户已实测确认: 鼠标移到视口最右侧 10px 把手区域才会触发 hover 展开, footer 右侧内容不再被遮挡。

## 文件变更

- apps/web/src/components/dev/DevToolsTrigger.tsx (4 insertions, 5 deletions)